### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/doc-portal.yml
+++ b/.github/workflows/doc-portal.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout Source
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        # 4.1.5
+        uses: JamesIves/github-pages-deploy-action@0f24da7de3e7e135102609a4c9633b025be8411b
         env:
           DEPLOY_BRANCH: doc-portal
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,8 @@ jobs:
           yarn install
           yarn build
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        # v4
+        uses: rlespinasse/github-slug-action@a362e5fb42057a3a23a62218b050838f1bacca5d
       # - name: Validate Tag
       #   run: |
       #     cd app-services-sdk-js

--- a/.github/workflows/release-java.yaml
+++ b/.github/workflows/release-java.yaml
@@ -27,7 +27,8 @@ jobs:
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG              
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        # v4
+        uses: rlespinasse/github-slug-action@a362e5fb42057a3a23a62218b050838f1bacca5d
       - name: Validate Tag
         run: npx semver $GITHUB_REF_SLUG
       - name: Version and build kafka-management-sdk
@@ -97,14 +98,16 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}  
       - name: Install git-chglog
-        uses: craicoverflow/install-git-chglog@v1
+        # v1
+        uses: craicoverflow/install-git-chglog@6d338c1d96dcbf12a2115fbe8e5b9817293aae33
       - name: Generate changelog
         run: |
           echo "CHANGELOG<<EOF" >> $GITHUB_ENV
           echo "$(git-chglog $GITHUB_REF_SLUG 2> /dev/null || echo '**PRERELEASE**')" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Update Release Notes
-        uses: meeDamian/github-release@2.0
+        # 2.0
+        uses: meeDamian/github-release@7ae19492500104f636b3fee4d8103af0fed36c8e
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ env.CHANGELOG }}

--- a/.github/workflows/sdk-update.yaml
+++ b/.github/workflows/sdk-update.yaml
@@ -37,7 +37,8 @@ jobs:
       - name: Generate errors
         run: node scripts/errors/generate_errors.js
       - name: Make pull request
-        uses: peter-evans/create-pull-request@v4
+        # v4
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
         with:
           title: "chore(all): re-generate SDKs"
           commit-message: "chore(all): re-generate OpenAPI client(s)"


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.